### PR TITLE
Add control to enable/disable axon ingress

### DIFF
--- a/charts/axonserver/Chart.yaml
+++ b/charts/axonserver/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "4.4"
 description: A Helm chart for running the Axon Server(https://docs.axoniq.io/reference-guide/axon-server/installation/docker-k8s) on Kubernetes
 name: axonserver
-version: 0.3.8
+version: 0.3.9

--- a/charts/axonserver/templates/ingress.yaml
+++ b/charts/axonserver/templates/ingress.yaml
@@ -1,3 +1,4 @@
+{{ if eq .Values.ingress.enabled "true" }}
 ---
 apiVersion: extensions/v1beta1
 kind: Ingress
@@ -21,3 +22,4 @@ spec:
   - hosts:
     - {{ .Values.ingress.host }}
     secretName: {{.Values.ingress.tls_secret}}
+{{ end }}

--- a/charts/axonserver/values.yaml
+++ b/charts/axonserver/values.yaml
@@ -4,16 +4,16 @@ app:
 
 statefulset:
   podManagementPolicy: Parallel
-# The 'replicas' value applies to the axonserver-ee only.
-# For the axonserver-se platform is set to "replicas: 1" 
+  # The 'replicas' value applies to the axonserver-ee only.
+  # For the axonserver-se platform is set to "replicas: 1"
   replicas: 3
   container:
     image: axoniq/axonserver
     workdir: /axonserver
     pullPolicy: Always
-  
+
   env: []
-  
+
   readiness:
     initialDelaySeconds: 5
     periodSeconds: 5
@@ -31,23 +31,23 @@ statefulset:
 volumeClaimTemplates:
   storageClassName: ""
   events:
-    accessModes: 
-    - ReadWriteOnce
+    accessModes:
+      - ReadWriteOnce
     storage: 5Gi
   data:
     accessModes:
-    - ReadWriteOnce
+      - ReadWriteOnce
     storage: 1Gi
   snapshots:
     accessModes:
-    - ReadWriteOnce
+      - ReadWriteOnce
     storage: 5Gi
 
 axoniq:
   axonserver:
     devmode:
       enabled: false
-    # The licenseBase64 value is optional and it applies to the axonserver-ee only. 
+    # The licenseBase64 value is optional and it applies to the axonserver-ee only.
     licenseBase64: ""
     admin:
       userName: "admin"
@@ -61,13 +61,14 @@ axoniq:
     systemToken: ""
     propertiesBase64: ""
     clusterTemplateBase64: ""
-    
+
 service:
   ports:
     grpc: "8124"
     gui: "8024"
 
 ingress:
+  enabled: false
   host: ""
   annotations: {}
   tls_secret: axonserver-tls


### PR DESCRIPTION
Axonserver chart version updated to: 0.3.9
axon ingress.yaml modified to apply the ingress (or not) based on the value of the variable "Values.ingress.enabled"
axon values.yaml update to receive the new variable "enabled" into the "ingress" block. 