### PR TITLE
fix token generation

### DIFF
--- a/charts/axonserver/templates/_helpers.tpl
+++ b/charts/axonserver/templates/_helpers.tpl
@@ -1,5 +1,5 @@
 {{- define "generateSystemToken" -}}
-printf "%s-%s-%s-%s-%s" {{randAlphaNum 8 }} {{ randAlphaNum 4 }} {{ randAlphaNum 4 }} {{ randAlphaNum 4 }} {{ randAlphaNum 12}}
+"{{randAlphaNum 8 }}-{{ randAlphaNum 4 }}-{{ randAlphaNum 4 }}-{{ randAlphaNum 4 }}-{{ randAlphaNum 12}}"
 {{- end -}}
 
 {{/* Expand 'axonserver.properties' */}}


### PR DESCRIPTION
This fixes the token generation part for `axonserver-system-token` secret.

You can test with `helm template axonserver .`

Before:
```
---
# Source: axonserver/templates/secret.yaml
apiVersion: v1
kind: Secret
metadata:
  name: axonserver-system-token
type: Opaque
stringData:
  axoniq.token: printf "%s-%s-%s-%s-%s" 8Aa10XyE Wi46 3vv7 s0Zb AMAYZj2GFbDB
```

After:
```
---
# Source: axonserver/templates/secret.yaml
apiVersion: v1
kind: Secret
metadata:
  name: axonserver-system-token
type: Opaque
stringData:
  axoniq.token: "1lrjuLnk-ETQS-D97b-tWZw-gjctylu8TtWG"
```