### PR TITLE
chore(charts/axonserver/): increase gRPC message size

### DIFF
--- a/charts/axonserver/templates/_helpers.tpl
+++ b/charts/axonserver/templates/_helpers.tpl
@@ -12,6 +12,8 @@ axoniq.axonserver.controldb-path={{.Values.statefulset.container.workdir }}/data
 
 axoniq.axonserver.pid-file-location={{.Values.statefulset.container.workdir }}/data
 
+axoniq.axonserver.max-message-size=10485760
+
 logging.file={{.Values.statefulset.container.workdir }}/log/axonserver.log
 logging.file.max-history={{ .Values.axoniq.axonserver.properties.logging.maxHistory | default "10"}}
 logging.file.max-size={{ .Values.axoniq.axonserver.properties.logging.maxSize | default "10MB"}}


### PR DESCRIPTION
## Context
<!--
Please include context and motivation for the PR.
-->

Fix this error message
`axonserver-1-0 io.grpc.StatusRuntimeException: RESOURCE_EXHAUSTED: gRPC message exceeds maximum size 4194304: 6540415` 

## References

- https://trustdsolutions.slack.com/archives/C02B1NXHNUU/p1683642289280489